### PR TITLE
Update gpsHUD to Python 3 and QT6

### DIFF
--- a/GPS_HUD.py
+++ b/GPS_HUD.py
@@ -106,7 +106,7 @@ class MainWidget(QtGui.QMainWindow, Ui_WidgetWindow):
 		try:
 			self.loadImage('preview.png')
 		except Exception as e:
-			print 'Loading template due to error:', e
+			print('Loading template due to error:', e)
 			self.loadImage(self.template_path)
 
 	def export(self):
@@ -153,7 +153,7 @@ class MainWidget(QtGui.QMainWindow, Ui_WidgetWindow):
 			try:
 				self.animate.export(path, exportFormat, fps=self.doubleSpinBox_fps.value())
 			except Exception as e:
-				print e
+				print(e)
 				os.remove(path)
 			self.processBarActive = False
 			self.toolButton_export.setEnabled(True)

--- a/GPS_HUD.py
+++ b/GPS_HUD.py
@@ -1,228 +1,225 @@
 import sys
 import os
-from PyQt4 import QtCore, QtGui, uic
+from PyQt5 import QtWidgets, QtGui, QtCore, uic
 import animateHUD
 
-__version__ = 'v1.0.0b'
+__version__ = 'v1.1.0'
 
 # add working directory temporarily to PYTHONPATH
 if getattr(sys, 'frozen', False):
-	# program runs in a bundle (pyinstaller)
-	execdir = sys._MEIPASS
+        # program runs in a bundle (pyinstaller)
+        execdir = sys._MEIPASS
 else:
-	execdir = os.path.dirname(os.path.realpath(__file__))
+        execdir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(execdir)
 
 qtCreatorFile_main = os.path.join(execdir, "GPS_HUD.ui")
 Ui_WidgetWindow, QtBaseClass = uic.loadUiType(qtCreatorFile_main)
 
 
-class MainWidget(QtGui.QMainWindow, Ui_WidgetWindow):
-	def __init__(self):
-		QtGui.QWidget.__init__(self)
-		Ui_WidgetWindow.__init__(self)
-		self.setupUi(self)
+class MainWidget(QtWidgets.QMainWindow, Ui_WidgetWindow):
+        def __init__(self):
+                QtWidgets.QWidget.__init__(self)
+                Ui_WidgetWindow.__init__(self)
+                self.setupUi(self)
 
-		## Initialize default values
-		self.lastPath_export = execdir
-		self.lastPath_template = execdir
-		self.lastPath_gpx = execdir
-		self.p_color = (255,180,0)
-		self.p_glow_Color = (255,120,0)
-		self.gpx_path = None
-		self.processBarActive = False
-		self.cancelExport = False
+                ## Initialize default values
+                self.lastPath_export = execdir
+                self.lastPath_template = execdir
+                self.lastPath_gpx = execdir
+                self.p_color = (255,180,0)
+                self.p_glow_Color = (255,120,0)
+                self.gpx_path = None
+                self.processBarActive = False
+                self.cancelExport = False
 
-		## Buttons
-		self.toolButton_template_select.clicked.connect(self.selectTemplate)
-		self.toolButton_gpx_select.clicked.connect(self.selectGPX)
-		self.toolButton_p_color_select.clicked.connect(self.getPointerColor)
-		self.toolButton_p_glow_color_select.clicked.connect(self.getPointerGlowColor)
-		self.toolButton_preview.clicked.connect(self.preview)
-		self.toolButton_export.clicked.connect(self.export)
-		self.toolButton_cancelExport.clicked.connect(self.setCancelExport)
+                ## Buttons
+                self.toolButton_template_select.clicked.connect(self.selectTemplate)
+                self.toolButton_gpx_select.clicked.connect(self.selectGPX)
+                self.toolButton_p_color_select.clicked.connect(self.getPointerColor)
+                self.toolButton_p_glow_color_select.clicked.connect(self.getPointerGlowColor)
+                self.toolButton_preview.clicked.connect(self.preview)
+                self.toolButton_export.clicked.connect(self.export)
+                self.toolButton_cancelExport.clicked.connect(self.setCancelExport)
 
-		self.animate = animateHUD.AnimateHUD(self)
-		self.loadImage(None)
+                self.animate = animateHUD.AnimateHUD(self)
+                self.loadImage(None)
 
-	def selectTemplate(self):
-		path = str(QtGui.QFileDialog.getOpenFileName(
-			None,"Select image file as template", self.lastPath_template,"Image Files (*.png);; All (*.*)"))
-		if path:
-			self.template_path = path
-			self.lineEdit_template_path.setText(path)
-			self.lastPath_template = path
-			self.loadImage(path)
+        def selectTemplate(self):
+                path, filter = QtWidgets.QFileDialog.getOpenFileName(None,"Select image file as template", self.lastPath_template,"Image Files (*.png);; All (*.*)")
+                if path:
+                        self.template_path = path
+                        self.lineEdit_template_path.setText(path)
+                        self.lastPath_template = path
+                        self.loadImage(path)
 
-	def loadImage(self,path=None):
-		self.scene = QGraphicsSceneCustom(self.graphicsView, mainWidget=self)
-		if path is None:
-			try:
-				self.pixmap = QtGui.QPixmap(os.path.join(execdir,'templates/blank.png'))
-				self.template_path = os.path.join(execdir,'templates/blank.png')
-			except Exception as e:
-				raise e
-		else:
-			self.pixmap = QtGui.QPixmap(path)
-		QtGui.QGraphicsPixmapItem(self.pixmap, None, self.scene)
-		## Add frame
-		self.scene.addRect(0,0,self.pixmap.width(),self.pixmap.height(), pen=QtGui.QPen(QtCore.Qt.black))
-		## connect scenes to GUI elements
-		self.graphicsView.setScene(self.scene)
-		## reset scaling (needed for reinitialization)
-		self.graphicsView.resetMatrix()
-		## scaling scene, not image
-		canvas_size = min([self.graphicsView.width(), self.graphicsView.height()])
-		img_size = max(self.pixmap.width(), self.pixmap.height())
-		# print canvas_size, img_size
-		if img_size > canvas_size:
-			scaling_factor = canvas_size/(float(img_size)+4)
-			self.graphicsView.scale(scaling_factor,scaling_factor)
+        def loadImage(self,path=None):
+                self.scene = QGraphicsSceneCustom(self.graphicsView, mainWidget=self)
+                if path is None:
+                        try:
+                                self.pixmap = QtGui.QPixmap(os.path.join(execdir,'templates/blank.png'))
+                                self.template_path = os.path.join(execdir,'templates/blank.png')
+                        except Exception as e:
+                                raise e
+                else:
+                        self.pixmap = QtGui.QPixmap(path)
 
-	def selectGPX(self):
-		path = str(QtGui.QFileDialog.getOpenFileName(
-			None,"Select gpx file", self.lastPath_gpx,"Image Files (*.gpx);; All (*.*)"))
-		if path:
-			self.gpx_path = path
-			self.lastPath_gpx = path
-			self.lineEdit_gpx_path.setText(path)
+                self.scene.addItem(QtWidgets.QGraphicsPixmapItem(self.pixmap))
 
-	def getPointerColor(self):
-		color = QtGui.QColorDialog.getColor()
-		if color.isValid():
-			self.p_color = (color.red(), color.green(), color.blue())
-			self.label_p_color.setStyleSheet("background-color: rgb{0};".format((color.red(), color.green(), color.blue())))
+                ## Add frame
+                self.scene.addRect(0,0,self.pixmap.width(),self.pixmap.height(), pen=QtGui.QPen(QtCore.Qt.black))
+                ## connect scenes to GUI elements
+                self.graphicsView.setScene(self.scene)
+                ## reset scaling (needed for reinitialization)
+                self.graphicsView.resetTransform()
 
-	def getPointerGlowColor(self):
-		color = QtGui.QColorDialog.getColor()
-		if color.isValid():
-			self.p_glow_Color = (color.red(), color.green(), color.blue())
-			self.label_p_glow_color.setStyleSheet("background-color: rgb{0};".format((color.red(), color.green(), color.blue())))
+                ## scaling scene, not image
+                canvas_size = min([self.graphicsView.width(), self.graphicsView.height()])
+                img_size = max(self.pixmap.width(), self.pixmap.height())
+                # print canvas_size, img_size
+                if img_size > canvas_size:
+                        scaling_factor = canvas_size/(float(img_size)+4)
+                        self.graphicsView.scale(scaling_factor,scaling_factor)
 
-	def preview(self,t=0):
-		self.animate.loadParams()
-		self.animate.generateClips()
-		self.animate.preview(t=t)
-		try:
-			self.loadImage('preview.png')
-		except Exception as e:
-			print('Loading template due to error:', e)
-			self.loadImage(self.template_path)
+        def selectGPX(self):
+                path, filter = QtWidgets.QFileDialog.getOpenFileName(None,"Select gpx file", self.lastPath_gpx,"Image Files (*.gpx);; All (*.*)")
+                if path:
+                        self.gpx_path = path
+                        self.lastPath_gpx = path
+                        self.lineEdit_gpx_path.setText(path)
 
-	def export(self):
-		self.animate.loadParams()
-		self.animate.generateClips()
-		self.processBarActive = True
-		self.processBarExport(p=None,initialize=True)
-		QtGui.QApplication.processEvents()
-		exportFormat = None
+        def getPointerColor(self):
+                color = QtWidgets.QColorDialog.getColor()
+                if color.isValid():
+                        self.p_color = (color.red(), color.green(), color.blue())
+                        self.label_p_color.setStyleSheet("background-color: rgb{0};".format((color.red(), color.green(), color.blue())))
 
-		if self.comboBox_export_format.currentText() == 'image sequence (.png)':
-			path = str(QtGui.QFileDialog.getExistingDirectory(self, "Select image sequence destination folder", self.lastPath_export))
-			if path:
-				exportFormat = 'imageSequence'
-				self.lastPath_export = path
-		elif self.comboBox_export_format.currentText() == 'gif':
-			path = str(QtGui.QFileDialog.getSaveFileName(
-				self, "Save File", os.path.join(self.lastPath_export,'gauge_export.gif'), "GIF (*.gif)"))
-			if path:
-				exportFormat = 'gif'
-				self.lastPath_export = os.path.split(path)[0]
-		elif self.comboBox_export_format.currentText() == 'mp4 (h264)':
-			path = str(QtGui.QFileDialog.getSaveFileName(
-				self, "Save File", os.path.join(self.lastPath_export,'gauge_export.mp4'), "h.264 (*.mp4)"))
-			if path:
-				exportFormat = 'mp4'
-				self.lastPath_export = os.path.split(path)[0]
-		elif self.comboBox_export_format.currentText() == 'avi (raw)':
-			path = str(QtGui.QFileDialog.getSaveFileName(
-				self, "Save File", os.path.join(self.lastPath_export,'gauge_export.avi'), "AVI (rawvideo) (*.avi)"))
-			if path:
-				exportFormat = 'aviRAW'
-				self.lastPath_export = os.path.split(path)[0]
-		elif self.comboBox_export_format.currentText() == 'avi (png)':
-			path = str(QtGui.QFileDialog.getSaveFileName(
-				self, "Save File", os.path.join(self.lastPath_export,'gauge_export.avi'), "AVI (PNG) (*.avi)"))
-			if path:
-				exportFormat = 'aviPNG'
-				self.lastPath_export = os.path.split(path)[0]
+        def getPointerGlowColor(self):
+                color = QtWidgets.QColorDialog.getColor()
+                if color.isValid():
+                        self.p_glow_Color = (color.red(), color.green(), color.blue())
+                        self.label_p_glow_color.setStyleSheet("background-color: rgb{0};".format((color.red(), color.green(), color.blue())))
 
-		if exportFormat is not None:
-			self.toolButton_export.setEnabled(False)
-			self.toolButton_cancelExport.setEnabled(True)
-			try:
-				self.animate.export(path, exportFormat, fps=self.doubleSpinBox_fps.value())
-			except Exception as e:
-				print(e)
-				os.remove(path)
-			self.processBarActive = False
-			self.toolButton_export.setEnabled(True)
-			self.toolButton_cancelExport.setEnabled(False)
-			self.cancelExport = False
-			QtGui.QApplication.processEvents()
+        def preview(self,t=0):
+                self.animate.loadParams()
+                self.animate.generateClips()
+                self.animate.preview(t=t)
+                try:
+                        self.loadImage('preview.png')
+                except Exception as e:
+                        print('Loading template due to error:', e)
+                        self.loadImage(self.template_path)
 
-	def setCancelExport(self):
-		self.cancelExport = True
+        def export(self):
+                self.animate.loadParams()
+                self.animate.generateClips()
+                self.processBarActive = True
+                self.processBarExport(p=None,initialize=True)
+                QtWidgets.QApplication.processEvents()
+                exportFormat = None
 
-	def processBarExport(self,p=None,initialize=False):
-		if initialize is True:
-			self.progressBar_export.setValue(0)
-			self.progressBar_export.reset()
-			self.progressBar_export.setMaximum(2*int(self.animate.duration*self.doubleSpinBox_fps.value()))
-			QtGui.QApplication.processEvents()
-		if p and self.processBarActive:
-			self.progressBar_export.setValue(self.progressBar_export.value()+p)
-			QtGui.QApplication.processEvents()
+                if self.comboBox_export_format.currentText() == 'image sequence (.png)':
+                        path = str(QtWidgets.QFileDialog.getExistingDirectory(self, "Select image sequence destination folder", self.lastPath_export))
+                        if path:
+                                exportFormat = 'imageSequence'
+                                self.lastPath_export = path
+                elif self.comboBox_export_format.currentText() == 'gif':
+                        path, filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", os.path.join(self.lastPath_export,'gauge_export.gif'), "GIF (*.gif)")
+                        if path:
+                                exportFormat = 'gif'
+                                self.lastPath_export = os.path.split(path)[0]
+                elif self.comboBox_export_format.currentText() == 'mp4 (h264)':
+                        path, filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", os.path.join(self.lastPath_export,'gauge_export.mp4'), "h.264 (*.mp4)")
+                        if path:
+                                exportFormat = 'mp4'
+                                self.lastPath_export = os.path.split(path)[0]
+                elif self.comboBox_export_format.currentText() == 'avi (raw)':
+                        path, filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", os.path.join(self.lastPath_export,'gauge_export.avi'), "AVI (rawvideo) (*.avi)")
+                        if path:
+                                exportFormat = 'aviRAW'
+                                self.lastPath_export = os.path.split(path)[0]
+                elif self.comboBox_export_format.currentText() == 'avi (png)':
+                        path, filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", os.path.join(self.lastPath_export,'gauge_export.avi'), "AVI (PNG) (*.avi)")
+                        if path:
+                                exportFormat = 'aviPNG'
+                                self.lastPath_export = os.path.split(path)[0]
+
+                if exportFormat is not None:
+                        self.toolButton_export.setEnabled(False)
+                        self.toolButton_cancelExport.setEnabled(True)
+                        try:
+                                self.animate.export(path, exportFormat, fps=self.doubleSpinBox_fps.value())
+                        except Exception as e:
+                                print(e)
+                                os.remove(path)
+                        self.processBarActive = False
+                        self.toolButton_export.setEnabled(True)
+                        self.toolButton_cancelExport.setEnabled(False)
+                        self.cancelExport = False
+                        QtWidgets.QApplication.processEvents()
+
+        def setCancelExport(self):
+                self.cancelExport = True
+
+        def processBarExport(self,p=None,initialize=False):
+                if initialize is True:
+                        self.progressBar_export.setValue(0)
+                        self.progressBar_export.reset()
+                        self.progressBar_export.setMaximum(2*int(self.animate.duration*self.doubleSpinBox_fps.value()))
+                        QtWidgets.QApplication.processEvents()
+                if p and self.processBarActive:
+                        self.progressBar_export.setValue(self.progressBar_export.value()+p)
+                        QtWidgets.QApplication.processEvents()
 
 
-class QGraphicsSceneCustom(QtGui.QGraphicsScene):
-	def __init__(self,parent=None,mainWidget=None):
-		self.mainWidget = mainWidget
-		## parent is QGraphicsView
-		QtGui.QGraphicsScene.__init__(self,parent)
-		self.parent().setDragMode(QtGui.QGraphicsView.NoDrag)
-		## Initialize variables
-		self.lastScreenPos = QtCore.QPoint(0, 0)
-		self.lastScenePos = 0
+class QGraphicsSceneCustom(QtWidgets.QGraphicsScene):
+        def __init__(self,parent=None,mainWidget=None):
+                self.mainWidget = mainWidget
+                ## parent is QGraphicsView
+                QtWidgets.QGraphicsScene.__init__(self,parent)
+                self.parent().setDragMode(QtWidgets.QGraphicsView.NoDrag)
+                ## Initialize variables
+                self.lastScreenPos = QtCore.QPoint(0, 0)
+                self.lastScenePos = 0
 
-	def wheelEvent(self, event):
-		## Scaling
-		if event.delta() > 0:
-			scalingFactor = 1.15
-		else:
-			scalingFactor = 1 / 1.15
-		self.parent().scale(scalingFactor, scalingFactor)
-		## Center on mouse pos only if mouse moved mor then 25px
-		if (event.screenPos() - self.lastScreenPos).manhattanLength() > 25:
-			self.parent().centerOn(event.scenePos().x(), event.scenePos().y())
-			self.lastScenePos = event.scenePos()
-		else:
-			self.parent().centerOn(self.lastScenePos.x(), self.lastScenePos.y())
-		## Save pos for precise scrolling, i.e. centering view only when mouse moved
-		self.lastScreenPos = event.screenPos()
+        def wheelEvent(self, event):
+                ## Scaling
+                if event.delta() > 0:
+                        scalingFactor = 1.15
+                else:
+                        scalingFactor = 1 / 1.15
+                self.parent().scale(scalingFactor, scalingFactor)
+                ## Center on mouse pos only if mouse moved mor then 25px
+                if (event.screenPos() - self.lastScreenPos).manhattanLength() > 25:
+                        self.parent().centerOn(event.scenePos().x(), event.scenePos().y())
+                        self.lastScenePos = event.scenePos()
+                else:
+                        self.parent().centerOn(self.lastScenePos.x(), self.lastScenePos.y())
+                ## Save pos for precise scrolling, i.e. centering view only when mouse moved
+                self.lastScreenPos = event.screenPos()
 
-	def mousePressEvent(self, event):
-		modifiers = QtGui.QApplication.keyboardModifiers()
-		if event.button() == QtCore.Qt.LeftButton and modifiers != QtCore.Qt.ControlModifier:
-			# print 'Mouse left button'
-			self.parent().setDragMode(QtGui.QGraphicsView.ScrollHandDrag)
-		# elif event.button() == QtCore.Qt.LeftButton and modifiers == QtCore.Qt.ControlModifier:
-			# print 'Mouse left button + ctrl'
-		elif event.button() == QtCore.Qt.RightButton:
-			# print 'Mouse right button at', event.scenePos().x(), event.scenePos().y()
-			self.mainWidget.spinBox_p_rot_center_x.setValue(int(event.scenePos().x()))
-			self.mainWidget.spinBox_p_rot_center_y.setValue(int(event.scenePos().y()))
-		# elif event.button() == QtCore.Qt.MiddleButton:
-			# print 'Mouse middle button'
+        def mousePressEvent(self, event):
+                modifiers = QtWidgets.QApplication.keyboardModifiers()
+                if event.button() == QtCore.Qt.LeftButton and modifiers != QtCore.Qt.ControlModifier:
+                        # print 'Mouse left button'
+                        self.parent().setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
+                # elif event.button() == QtCore.Qt.LeftButton and modifiers == QtCore.Qt.ControlModifier:
+                        # print 'Mouse left button + ctrl'
+                elif event.button() == QtCore.Qt.RightButton:
+                        # print 'Mouse right button at', event.scenePos().x(), event.scenePos().y()
+                        self.mainWidget.spinBox_p_rot_center_x.setValue(int(event.scenePos().x()))
+                        self.mainWidget.spinBox_p_rot_center_y.setValue(int(event.scenePos().y()))
+                # elif event.button() == QtCore.Qt.MiddleButton:
+                        # print 'Mouse middle button'
 
-	def mouseReleaseEvent(self, event):
-		super(QGraphicsSceneCustom, self).mouseReleaseEvent(event)
-		self.parent().setDragMode(QtGui.QGraphicsView.NoDrag)
+        def mouseReleaseEvent(self, event):
+                super(QGraphicsSceneCustom, self).mouseReleaseEvent(event)
+                self.parent().setDragMode(QtWidgets.QGraphicsView.NoDrag)
 
 
 if __name__ == "__main__":
-	app = QtGui.QApplication(sys.argv)
-	window = MainWidget()
-	window.show()
-	window.raise_()
-	sys.exit(app.exec_())
+        app = QtWidgets.QApplication(sys.argv)
+        window = MainWidget()
+        window.show()
+        window.raise_()
+        sys.exit(app.exec_())

--- a/GPS_HUD.py
+++ b/GPS_HUD.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from PyQt5 import QtWidgets, QtGui, QtCore, uic
+from PyQt6 import QtWidgets, QtGui, QtCore, uic
 import animateHUD
 
 __version__ = 'v1.1.0'
@@ -67,7 +67,7 @@ class MainWidget(QtWidgets.QMainWindow, Ui_WidgetWindow):
                 self.scene.addItem(QtWidgets.QGraphicsPixmapItem(self.pixmap))
 
                 ## Add frame
-                self.scene.addRect(0,0,self.pixmap.width(),self.pixmap.height(), pen=QtGui.QPen(QtCore.Qt.black))
+                self.scene.addRect(0,0,self.pixmap.width(),self.pixmap.height(), pen=QtGui.QPen())
                 ## connect scenes to GUI elements
                 self.graphicsView.setScene(self.scene)
                 ## reset scaling (needed for reinitialization)
@@ -177,7 +177,7 @@ class QGraphicsSceneCustom(QtWidgets.QGraphicsScene):
                 self.mainWidget = mainWidget
                 ## parent is QGraphicsView
                 QtWidgets.QGraphicsScene.__init__(self,parent)
-                self.parent().setDragMode(QtWidgets.QGraphicsView.NoDrag)
+                self.parent().setDragMode(QtWidgets.QGraphicsView.DragMode.NoDrag)
                 ## Initialize variables
                 self.lastScreenPos = QtCore.QPoint(0, 0)
                 self.lastScenePos = 0
@@ -202,7 +202,7 @@ class QGraphicsSceneCustom(QtWidgets.QGraphicsScene):
                 modifiers = QtWidgets.QApplication.keyboardModifiers()
                 if event.button() == QtCore.Qt.LeftButton and modifiers != QtCore.Qt.ControlModifier:
                         # print 'Mouse left button'
-                        self.parent().setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
+                        self.parent().setDragMode(QtWidgets.QGraphicsView.DragMode.ScrollHandDrag)
                 # elif event.button() == QtCore.Qt.LeftButton and modifiers == QtCore.Qt.ControlModifier:
                         # print 'Mouse left button + ctrl'
                 elif event.button() == QtCore.Qt.RightButton:
@@ -214,7 +214,7 @@ class QGraphicsSceneCustom(QtWidgets.QGraphicsScene):
 
         def mouseReleaseEvent(self, event):
                 super(QGraphicsSceneCustom, self).mouseReleaseEvent(event)
-                self.parent().setDragMode(QtWidgets.QGraphicsView.NoDrag)
+                self.parent().setDragMode(QtWidgets.QGraphicsView.DragMode.NoDrag)
 
 
 if __name__ == "__main__":
@@ -222,4 +222,4 @@ if __name__ == "__main__":
         window = MainWidget()
         window.show()
         window.raise_()
-        sys.exit(app.exec_())
+        sys.exit(app.exec())

--- a/gpx_parsing.py
+++ b/gpx_parsing.py
@@ -41,24 +41,24 @@ def get_interpolated_coordinate_list(path):
 					((bLon-aLon)/(bTim-aTim))*(second+1)+aLon,
 					((bEle-aEle)/(bTim-aTim))*(second+1)+aEle])
 			if debug:
-				print aTim, bTim, bTim-aTim
-				print point, ':', aLat, aLon, aEle
+				print(aTim, bTim, bTim-aTim)
+				print(point, ':', aLat, aLon, aEle)
 				for second in range(int(bTim-aTim-1)):
-					print(
-						'>>>>>', (((bLat-aLat)/(bTim-aTim))*(second+1))+aLat, ((bLon-aLon)/(bTim-aTim))*(second+1)+aLon, ((bEle-aEle)/(bTim-aTim))*(second+1)+aEle)
+					print((
+						'>>>>>', (((bLat-aLat)/(bTim-aTim))*(second+1))+aLat, ((bLon-aLon)/(bTim-aTim))*(second+1)+aLon, ((bEle-aEle)/(bTim-aTim))*(second+1)+aEle))
 					interpolated += 1
-				print point+1, ':', bLat, bLon, bEle
-				print '='*10
+				print(point+1, ':', bLat, bLon, bEle)
+				print('='*10)
 
 	if debug:
-		print 'Duration from file: ', gpx.get_duration()
-		print 'Duration calculated:', time.mktime(
-			gpx.tracks[0].segments[0].points[-1].time.timetuple())-time.mktime(gpx.tracks[0].segments[0].points[0].time.timetuple())
-		print 'Data points:        ', len(gpx.tracks[0].segments[0].points)
-		print 'Interpolated Points:', interpolated
-		print 'New Data Points:    ', len(gpx.tracks[0].segments[0].points) + interpolated
-		print '#'*50
-		print interpolated_list
+		print('Duration from file: ', gpx.get_duration())
+		print('Duration calculated:', time.mktime(
+			gpx.tracks[0].segments[0].points[-1].time.timetuple())-time.mktime(gpx.tracks[0].segments[0].points[0].time.timetuple()))
+		print('Data points:        ', len(gpx.tracks[0].segments[0].points))
+		print('Interpolated Points:', interpolated)
+		print('New Data Points:    ', len(gpx.tracks[0].segments[0].points) + interpolated)
+		print('#'*50)
+		print(interpolated_list)
 
 	return interpolated_list
 
@@ -107,5 +107,5 @@ if __name__ == '__main__':
 	i = 0
 	for speed in get_interpolated_speed_list(path):
 		# if i in [630,631,632]:
-		print i, speed*3.6
+		print(i, speed*3.6)
 		i += 1


### PR DESCRIPTION
I completed the Python 3 and QT6 migrations split across three issues, using QT Creator.  This caused a mixture of whitespace, of which Python complained.  I let QT Creator clean the whitespce, hence the large number of line changes.

Note: I kept the MoviePy package at version 1.03 and had to downgrade the Decorator package to version 4.4.2.  The 5.1.1 version of Decorator has a Python3 keyword argument bug, which caused the FPS to be null.